### PR TITLE
add: 投稿編集ページの追加

### DIFF
--- a/app/assets/stylesheets/reviews.scss
+++ b/app/assets/stylesheets/reviews.scss
@@ -113,7 +113,7 @@ padding-right: 40px;
   border-bottom: #666666 1px solid;
   align-items: center;
   font-size: 25px;
-  background-color: beige;
+  // background-color: beige;
 }
 
 .form-middle{
@@ -146,7 +146,7 @@ label{
 }
 
 .form-box{
-  background-color: cornsilk;
+  // background-color: cornsilk;
   height: 60vh;
   height:calc(85vh - 200px);
   margin-bottom: 10px;

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,4 +5,8 @@ class ReviewsController < ApplicationController
   def new
   end
 
+  def edit
+  end
+  
+
 end

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,0 +1,28 @@
+<div class="review-form">
+  <%= form_with model: @review, url:reviews_path, local: true do |f| %>
+    
+    <div class="form-upper">
+        <label for="title">Title: </label>
+        <%= f.text_field :title, class:"titme-form", id:"book-title", placeholder:" 必須(10文字まで)", maxlength:"20" %>
+    </div>
+
+    <div class="form-middle">
+      <label for="image" class="select-btn">Cover: </label>
+      <%= f.file_field :image, class:"image-form", id:"book-image" %>
+    </div>
+    <div class="form-bottom">
+      <div class="form-content">
+        <label for="category">Category: </label>
+        <%= f.collection_select(:category, [], :id, :name, {}, {class:"select-box", id:"book-category"}) %>
+      </div>
+      <div class="form-content">
+        <label for="time_limit">Time Limit: </label>
+          <P>7日</p>
+        </div>
+    </div>
+    <div class="form-box">
+      <%= f.text_area :text, class:"text-form", id:"review-title", placeholder:"2000文字まで登録できます", maxlength:"2000" %>
+    </div>
+    <%= f.submit "Review" ,class:"submit-btn" %>
+  <% end %>
+</div>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -23,6 +23,6 @@
     <div class="form-box">
       <%= f.text_area :text, class:"text-form", id:"review-title", placeholder:"2000文字まで登録できます", maxlength:"2000" %>
     </div>
-    <%= f.submit "Review" ,class:"submit-btn" %>
+    <%= f.submit "Edit" ,class:"submit-btn" %>
   <% end %>
 </div>


### PR DESCRIPTION
# what
- 投稿編集ページのビューファイルを実装
- 各投稿フォームの実装
# why
- 投稿編集画面表示のため
- フォーム表示のため
# 補足
 新規投稿ページとの違いは以下の２点のみ
- timelimitを編集できない点
- フォーム送信ボタンの文字