### PR TITLE
add: ユーザー編集ページのビュー作成

### DIFF
--- a/app/assets/stylesheets/reviews.scss
+++ b/app/assets/stylesheets/reviews.scss
@@ -149,7 +149,7 @@ padding:0 20px 0 20px;
   // background-color: blanchedalmond;
 }
 
-label{
+.review-container label{
   padding-right: 1vw;
 }
 

--- a/app/assets/stylesheets/user/registration.css
+++ b/app/assets/stylesheets/user/registration.css
@@ -19,7 +19,7 @@
 
 .user-field{
   text-align: center;
-  padding-bottom: 20px;
+  padding-bottom: 24px;
   font-size: 20px;
 }
 
@@ -43,4 +43,16 @@
 
 .error-space{
   padding: 50px 0px 40px 0px;
+}
+
+
+
+/* ユーザー編集ページ */
+
+.user-supplement{
+  font-size: 12px;
+}
+
+em{
+  font-size: 12px;
 }

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,39 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h1 class="user_edit heading">Edit user<%= resource_name.to_s.humanize %></h1>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="user-container">
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+    <div class="user-field">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <div class="user-field">
+      <%= f.label :password %><br/>
+      <i class="user-supplement">6文字以上です(変更しない場合は空欄で送信してください)</i><br />
+      <%= f.password_field :password, autocomplete: "new-password" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
+    <div class="user-field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
+    <div class="user-field">
+      <%= f.label :current_password %><br/>
+      <i class="user-supplement">(現在のPasswordを入力してください)</i><br />
+      <%= f.password_field :current_password, autocomplete: "current-password" %>
+    </div>
 
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+    <div class="user-actions">
+      <%= f.submit "Update" , class: "submit-btn"%>
+    </div>
+  <% end %>
+  <%= link_to "Back", :back %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -16,10 +16,8 @@
     </div>
 
     <div class="user-field">
-      <%= f.label :password %>
-      <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em>
-      <% end %><br />
+      <%= f.label :password %><br/>
+      <i class="user-supplement">6文字以上です</i><br />
       <%= f.password_field :password, autocomplete: "new-password" %>
     </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,7 @@
     </main>
     <footer>
       <div class="under-ber">
-        <%= link_to "UserNickname", "#" %>
+        <%= link_to "UserNickname", edit_user_registration_path %>
         <p class="footer-limit">レビュー期限 :７日</p>
         <%= link_to "Stencil", root_path %>
       </div>


### PR DESCRIPTION
# what
- ユーザー編集ページのビュー作成
- 各フォームの編集
# why
- ユーザー編集ページを表示させるため
- ユーザー編集用の入力フォーム実装するため
- ユーザー情報編集機能を実装するため

# 補足
- 各フォームは新規登録ページと同様
- 編集ページのみ、Currnt_passwordのフォームを実装